### PR TITLE
Switch from system() to QProcess

### DIFF
--- a/src/importfilter.cpp
+++ b/src/importfilter.cpp
@@ -22,6 +22,7 @@
 #include <QStandardPaths>
 #include <QLocale>
 #include <QDebug>
+#include <QProcess>
 
 #include <KLocalizedString>
 
@@ -80,9 +81,9 @@ bool ImportFilter::recode( const QString& file, const QString& outfile )
   QString cmd = DefaultProvider::self()->iconvTool();
 
   if ( QFile::exists( cmd ) ) {
-    QString command = QString( "%1 -f %2 -t utf-8 -o %3 %4" ).arg( cmd )
-                      .arg( mEncoding ).arg( outfile ).arg( file );
-    int result = system( command.toLocal8Bit().constData() );
+    QStringList args = QStringList()
+      << "-f" << mEncoding << "-t" << "utf-8" << "-o" << outfile << file;
+    int result = QProcess::execute( cmd, args );
     // qDebug () << "Recode finished with exit code " << result;
     return true;
   } else {


### PR DESCRIPTION
Using bare `system()` like this is not exactly safe:
- `system()` spawns a shell, which is not needed in this case
- arguments are not properly escaped/quoted, e.g. in case of spaces in paths (see above)
- there is no handling of signals, nor a way to make it async
- checking the result is an annoying task

Thus, just switch to `QProcess::execute()` instead:
- no shell used
- proper handling of arguments
- the execution is still synchronous, but this change allows to change it later if needed/wanted
- checking the result (which is still not done, and ought to be done actually) is easier