### PR TITLE
Switch to Python 3

### DIFF
--- a/src/reportgenerator.cpp
+++ b/src/reportgenerator.cpp
@@ -484,7 +484,7 @@ QStringList ReportGenerator::findTrml2Pdf( )
             p += QLatin1String("/tools/erml2pdf.py");
             // qDebug () << "Found erml2pdf from KRAFT_HOME: " << p;
             if( QFile::exists( p ) ) {
-                retList << "python";
+                retList << "python3";
                 retList << p;
                 mHavePdfMerge = true;
             }
@@ -492,14 +492,10 @@ QStringList ReportGenerator::findTrml2Pdf( )
             const QString ermlpy = QStandardPaths::locate(QStandardPaths::GenericDataLocation, "kraft/tools/erml2pdf.py" );
             // qDebug () << "Ermlpy: " << ermlpy;
             if( ! ermlpy.isEmpty() ) {
-                // need the python interpreter
-                // First check for python2 in python3 times.
-                QString python = QStandardPaths::findExecutable(QLatin1String("python2"));
+                // need the python3 interpreter, check for it
+                QString python = QStandardPaths::findExecutable(QLatin1String("python3"));
                 if( python.isEmpty() ) {
-                    python = QStandardPaths::findExecutable(QLatin1String("python"));
-                }
-                if( python.isEmpty() ) {
-                    qCritical() << "ERR: Unable to find python, thats a problem";
+                    qCritical() << "ERR: Unable to find python3, thats a problem";
                 } else {
                     // qDebug () << "Using python: " << python;
                     retList << python;
@@ -543,7 +539,7 @@ void ReportGenerator::runTrml2Pdf( const QString& rmlFile, const QString& docID,
 {
     mErrors.clear();
     // findTrml2Pdf returns a list of command line parts for the converter, such as
-    // /usr/bin/pyhton /usr/local/share/erml2pdf.py
+    // /usr/bin/pyhton3 /usr/local/share/erml2pdf.py
     QStringList rmlbin = findTrml2Pdf();
 
     if ( ! rmlbin.size() ) {

--- a/tools/erml2pdf.py
+++ b/tools/erml2pdf.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 # -*- coding: utf-8 -*-
 #
 # erml2pdf - An RML to PDF converter with extended features


### PR DESCRIPTION
Python 2 will be EOL by January 1st 2020, so switch kraft to Python 3 only -- it is widely available in distros anyway, so it should not be an issue.

The Python 2 code in `erml2pdf.py` was not removed ATM, it can be removed later on (e.g. to remove the use of `six`).