### PR TITLE
Convert newlines in item text to <p></p>

### DIFF
--- a/reports/invoice.gtmpl
+++ b/reports/invoice.gtmpl
@@ -46,7 +46,7 @@
     <link href="kraft.css" media="print" rel="stylesheet"/>
     <title>Kraft Document</title>
   </head>
-{% autoescape on %}
+{% autoescape off %}
   <body>
     <p id="letterheader">
     {{ me.ORGANISATION }} - {{ me.STREET }} - {{ me.POSTCODE }} {{ me.LOCALITY }}
@@ -86,7 +86,7 @@
           {% if item.kind == 'Alternative' or item.kind == 'Demand' %}
             <i>
           {% endif %}
-          {{ item.text }}
+          {{ item.htmlText }}
           {% if item.kind == 'Alternative' or item.kind == 'Demand' %}
             </i>
           {% endif %}

--- a/reports/invoice_kfg.gtmpl
+++ b/reports/invoice_kfg.gtmpl
@@ -50,7 +50,7 @@
     <title>Kraft Document</title>
   </head>
 
-  {% autoescape on %}
+  {% autoescape off %}
   <body>
 
     <!-- id vs class of html elements:
@@ -106,7 +106,7 @@
           {% if item.kind == 'Alternative' or item.kind == 'Demand' %}
             <i>
           {% endif %}
-          {{ item.text }}
+          {{ item.htmlText }}
           {% if item.kind == 'Alternative' or item.kind == 'Demand' %}
             </i>
           {% endif %}

--- a/src/archdocposition.cpp
+++ b/src/archdocposition.cpp
@@ -90,6 +90,21 @@ QString ArchDocPosition::taxMarkerHelper() const
     return re;
 }
 
+QString ArchDocPosition::htmlText(const QString& paraStyle) const
+{
+    QString re;
+
+    QString style( paraStyle );
+    if ( style.isEmpty() ) style = QStringLiteral("text");
+
+    // QStringList li = QStringList::split( "\n", escapeTrml2pdfXML( str ) );
+    QStringList li = mText.toHtmlEscaped().split( "\n" );
+    re = QString( "<p style=\"%1\">" ).arg( style );
+    re += li.join( QString( "</p><p style=\"%1\">" ).arg( style ) ) + QStringLiteral("</p>");
+    // qDebug () << "Returning " << rml;
+    return re;
+}
+
 // ==================================================================
 
 ArchDocPositionList::ArchDocPositionList()

--- a/src/archdocposition.h
+++ b/src/archdocposition.h
@@ -48,6 +48,7 @@ public:
     QString posNumber() const { return mPosNo; }
 
     QString text() const { return mText; }
+    QString htmlText(const QString &paraStyle = QString()) const;
 
     QString unit() const { return mUnit; }
 
@@ -106,6 +107,8 @@ if ( property == "itemNumber" )
     return object.posNumber();
 else if ( property == "text" )
     return object.text();
+else if ( property == "htmlText" )
+    return object.htmlText();
 else if ( property == "kind" )
     return object.kind();
 else if ( property == "unit" )

--- a/src/version.h
+++ b/src/version.h
@@ -1,4 +1,4 @@
-#define KRAFT_VERSION "0.95"
+#define KRAFT_VERSION "0.96"
 
 #define KRAFT_CODENAME "Gunny"
 


### PR DESCRIPTION
This converts newlines in the text of document items to <p> paragraphs in the weasyprint docs. They appear as linebreaks in the rendered document.