### PR TITLE
optimized layout "template for pdf creation"

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -70,7 +70,7 @@ $ mkdir build
 $ cd build
 $ cmake ..
     to generate the Makefiles.
-$ ccmake .
+$ cmake .
     to change the configuration of the build process. (optional)
 
 Check out for errors during the cmake run. Fix them, usually you need

--- a/src/doctypeeditbase.ui
+++ b/src/doctypeeditbase.ui
@@ -222,12 +222,34 @@
       <string>Template for PDF Creation</string>
      </property>
      <layout class="QGridLayout" name="gridLayout">
-      <item row="0" column="0" colspan="3">
-       <layout class="QHBoxLayout" name="horizontalLayout">
-        <item>
+      <item row="0" column="2">
+       <layout class="QGridLayout" name="gridLayout_3">
+        <item row="0" column="1">
+         <widget class="QLineEdit" name="mTemplateUrl"/>
+        </item>
+        <item row="1" column="1">
+         <widget class="QComboBox" name="mWatermarkCombo">
+          <item>
+           <property name="text">
+            <string>no watermark</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>on first page</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>on all pages</string>
+           </property>
+          </item>
+         </widget>
+        </item>
+        <item row="0" column="0">
          <widget class="QLabel" name="textLabel1">
           <property name="text">
-           <string>&amp;Template File</string>
+           <string>&amp;Template File:</string>
           </property>
           <property name="wordWrap">
            <bool>false</bool>
@@ -237,62 +259,23 @@
           </property>
          </widget>
         </item>
-        <item>
-         <widget class="QLineEdit" name="mTemplateUrl"/>
+        <item row="1" column="0">
+         <widget class="QLabel" name="textLabel2">
+          <property name="text">
+           <string>W&amp;atermark:</string>
+          </property>
+          <property name="wordWrap">
+           <bool>false</bool>
+          </property>
+          <property name="buddy">
+           <cstring>mWatermarkCombo</cstring>
+          </property>
+         </widget>
         </item>
-       </layout>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="textLabel2">
-        <property name="text">
-         <string>W&amp;atermark:</string>
-        </property>
-        <property name="wordWrap">
-         <bool>false</bool>
-        </property>
-        <property name="buddy">
-         <cstring>mWatermarkCombo</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QComboBox" name="mWatermarkCombo">
-        <item>
-         <property name="text">
-          <string>no watermark</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>on first page</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>on all pages</string>
-         </property>
-        </item>
-       </widget>
-      </item>
-      <item row="1" column="2">
-       <spacer name="horizontalSpacer">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>353</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item row="2" column="0" colspan="3">
-       <layout class="QHBoxLayout" name="horizontalLayout_2">
-        <item>
+        <item row="2" column="0">
          <widget class="QLabel" name="textLabel1_3">
           <property name="text">
-           <string>&amp;Watermark File</string>
+           <string>&amp;Watermark File:</string>
           </property>
           <property name="wordWrap">
            <bool>false</bool>
@@ -302,7 +285,7 @@
           </property>
          </widget>
         </item>
-        <item>
+        <item row="2" column="1">
          <widget class="QLineEdit" name="mWatermarkUrl"/>
         </item>
        </layout>


### PR DESCRIPTION
* nicer layout, use ":" consistently at the end of the labels;
* fixed typo in INSTALL file;

see before / after 
![settings_before_after](https://user-images.githubusercontent.com/644248/128603103-0286ca63-fd84-4e1c-bebf-7951f0bc2ad4.png)
