### PR TITLE
Adapt to new Akonadi includes in Akonadi 5.19

### DIFF
--- a/src/addressprovider_akonadi.cpp
+++ b/src/addressprovider_akonadi.cpp
@@ -21,16 +21,29 @@
 #include <QDebug>
 
 #ifdef HAVE_AKONADI
+#include "akonadi/contact/contactsearchjob.h"
+#include <akonadi_version.h>
+#if AKONADI_VERSION >= QT_VERSION_CHECK(5, 18, 41)
+#include <Akonadi/ItemFetchJob>
+#include <Akonadi/ItemFetchScope>
+
+#include <Akonadi/CollectionFetchJob>
+
+#include <Akonadi/ItemFetchJob>
+#include <Akonadi/ItemFetchScope>
+#include <Akonadi/EntityDisplayAttribute>
+#include <Akonadi/Control>
+#else
 #include <AkonadiCore/ItemFetchJob>
 #include <AkonadiCore/ItemFetchScope>
 
-#include "akonadi/contact/contactsearchjob.h"
 #include <AkonadiCore/CollectionFetchJob>
 
 #include <AkonadiCore/ItemFetchJob>
 #include <AkonadiCore/ItemFetchScope>
 #include <AkonadiCore/entitydisplayattribute.h>
 #include <AkonadiCore/control.h>
+#endif
 
 using namespace Akonadi;
 #endif

--- a/src/addressprovider_akonadi.h
+++ b/src/addressprovider_akonadi.h
@@ -25,9 +25,15 @@
 
 #ifdef HAVE_AKONADI
 #include <kjob.h>
+#include <akonadi/contact/contactstreemodel.h>
+#include <akonadi_version.h>
+#if AKONADI_VERSION >= QT_VERSION_CHECK(5, 18, 41)
+#include <Akonadi/Session>
+#include <Akonadi/ChangeRecorder>
+#else
 #include <AkonadiCore/session.h>
 #include <AkonadiCore/changerecorder.h>
-#include <akonadi/contact/contactstreemodel.h>
+#endif
 #endif
 
 class QAbstractItemModel;

--- a/src/addressselectorwidget.cpp
+++ b/src/addressselectorwidget.cpp
@@ -37,8 +37,14 @@
 #include <kcontacts/contactgroup.h>
 
 #ifdef HAVE_AKONADI
+#include <akonadi_version.h>
+#if AKONADI_VERSION >= QT_VERSION_CHECK(5, 18, 41)
+#include <Akonadi/EntityTreeModel>
+#include <Akonadi/EntityTreeView>
+#else
 #include <entitytreemodel.h>
 #include <entitytreeview.h>
+#endif
 #endif
 
 /* ==================================================================== */


### PR DESCRIPTION
The includes of the core Akonadi libraries have seen some clean-up to match the C++namespace, with no backward-compat. The new includes will be first needed with the releases part of KDE Gear 21.12.
As KDEPIM has not bound itself to SC/BC in the minor releases each quarter, sadly clients have to adapt this time.
The includes of the content specific Akonadi libraries (like akonadi-contacts) have not yet seen a similar update, so sadly some inconsistency for now. 

So ideally Kraft would see a new release before or in time of Gear 21.12 (planned Dec. 9th, see https://community.kde.org/Schedules/KDE_Gear_21.12_Schedule)