### PR TITLE
Port to KF5Grantlee

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,13 +40,23 @@ find_package(KF5 REQUIRED COMPONENTS
 )
 
 # Grantlee templating engine
-find_package(Grantlee5 REQUIRED)
-set_package_properties(Grantlee5 PROPERTIES
-    DESCRIPTION "Library for templating html and pdf output"
-    URL "https://www.grantlee.org/"
-    PURPOSE "Optionally used for templating"
-    TYPE OPTIONAL
-)
+set(USE_KFGRANTLEE FALSE)
+find_package(KF5Grantlee "5.88.0" CONFIG QUIET)
+if(KF5Grantlee_FOUND)
+    set_package_properties(KF5Grantlee PROPERTIES
+        TYPE REQUIRED
+    )
+    set(USE_KFGRANTLEE TRUE)
+else()
+    # try old non KFied Grantlee
+    find_package(Grantlee5 REQUIRED)
+    set_package_properties(Grantlee5 PROPERTIES
+        DESCRIPTION "Library for templating html and pdf output"
+        URL "https://www.grantlee.org/"
+        PURPOSE "Optionally used for templating"
+        TYPE OPTIONAL
+    )
+endif()
 
 find_package(KF5Akonadi)
 set_package_properties(KF5Akonadi PROPERTIES

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -160,8 +160,13 @@ set(KRAFT_LINK_LIBS
     KF5::ConfigCore
     KF5::ConfigGui
     ${CTEMPLATE_LIBRARIES} pthread
-    Grantlee5::Templates
 )
+if(USE_KFGRANTLEE)
+    list(APPEND KRAFT_LINK_LIBS KF5::Grantlee)
+else()
+    list(APPEND KRAFT_LINK_LIBS Grantlee5::Templates)
+endif()
+
 if(KF5Akonadi_FOUND)
   list(APPEND KRAFT_LINK_LIBS
     KF5::AkonadiCore
@@ -173,6 +178,9 @@ if(KF5Akonadi_FOUND)
 endif()
 
 add_library(kraftlib STATIC ${KRAFT_RC_SRC} ${kraft_SRCS})
+if(USE_KFGRANTLEE)
+    target_compile_definitions(kraftlib PUBLIC USE_KFGRANTLEE)
+endif()
 
 add_executable(kraft main.cpp)
 

--- a/src/grantleetemplate.cpp
+++ b/src/grantleetemplate.cpp
@@ -26,7 +26,11 @@
 #include <grantlee/engine.h>
 #include <grantlee/context.h>
 #include <grantlee/template.h>
+#ifdef USE_KFGRANTLEE
+#include <grantlee/filesystemtemplateloader.h>
+#else
 #include <grantlee/templateloader.h>
+#endif
 
 GrantleeFileTemplate::GrantleeFileTemplate( const QString& file)
     :_tmplFileName(file)
@@ -50,7 +54,11 @@ QString GrantleeFileTemplate::render(bool &ok) const
     QFileInfo fi(_tmplFileName);
     ok = true; // assume all goes well.
 
+#ifdef USE_KFGRANTLEE
+    auto loader = std::make_shared<Grantlee::FileSystemTemplateLoader>();
+#else
     auto loader = QSharedPointer<Grantlee::FileSystemTemplateLoader>::create();
+#endif
     loader->setTemplateDirs( {fi.absolutePath()} );
     engine->addTemplateLoader( loader );
 


### PR DESCRIPTION
There is an active plan to import Grantlee as KDE Frameworks module in time for KDE Frameworks 5.88 begin of November. Not yet set in stone, but worked for right now.

See https://phabricator.kde.org/T14887 for details.

The KF varient of Grantlee will not be a drop-in replacement, but needs some adaption on CMake & code level, as done by this patch. This patch is the currently needed adaption to that. So this MR is just a preview of what will be needed.

Ideally would be part of a new Kraft release together with #116  in time for KDE Gear 21.12. So Linux distributions can switch all their packages to KFGrantlee and avoid any potential symbol clashes (as the Grantlee C++ namespace is used also in the KF variant).