### PR TITLE
Build AppImages on GitHub

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,73 @@
+name: CI
+
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  appimage-build:
+    runs-on: ubuntu-latest
+    container: opensuse/leap:15.2
+    steps:
+      # need to install Git >= 2.18 before checkout according to GitHub actions
+      # we can just install all the dependencies beforehand, though
+      - name: Install dependencies
+        run: |
+          zypper install -y \
+            gcc \
+            gcc-c++ \
+            cmake \
+            make \
+            wget \
+            git \
+            extra-cmake-modules \
+            libctemplate-devel pkgconf \
+            "cmake(Grantlee5)" \
+            "cmake(KF5Codecs)" \
+            "cmake(KF5Config)" \
+            "cmake(KF5Contacts)" \
+            "cmake(KF5I18n)" \
+            "cmake(Qt5Core)" \
+            "cmake(Qt5Gui)" \
+            "cmake(Qt5Sql)" \
+            "cmake(Qt5Test)" \
+            "cmake(Qt5Widgets)" \
+            "cmake(Qt5Xml)" \
+            libQt5Sql5-sqlite \
+            libqt5-qtdeclarative-tools
+
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Build AppImage
+        run: |
+          export APPIMAGE_EXTRACT_AND_RUN=1
+          wget https://github.com/TheAssassin/appimagecraft/releases/download/continuous/appimagecraft-x86_64.AppImage
+          chmod +x appimagecraft-x86_64.AppImage
+          ./appimagecraft-x86_64.AppImage
+
+      - name: Archive artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          if-no-files-found: error
+          name: AppImage
+          path: |
+            Kraft*.AppImage*
+
+  upload:
+    name: Create release and upload artifacts
+    needs:
+      - appimage-build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v2
+      - name: Inspect directory after downloading artifacts
+        run: ls -alFR
+      - name: Create release and upload artifacts
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+            wget -q https://github.com/TheAssassin/pyuploadtool/releases/download/continuous/pyuploadtool-x86_64.AppImage
+            chmod +x pyuploadtool-x86_64.AppImage
+            ./pyuploadtool-x86_64.AppImage **/Kraft*.AppImage*

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 build
+*.*swp*
+*.AppImage*

--- a/appimagecraft.yml
+++ b/appimagecraft.yml
@@ -7,9 +7,25 @@ project:
 build:
   cmake:
 
+scripts:
+  post_build:
+    # make sure weasyprint can be launched from a path next to the kraft binary
+    # this simplifies the lookup greatly
+    # also, if we create the file now (i.e., before linuxdeploy runs), it won't be overwritten by the python plugin
+    - |
+      cat > "$BUILD_DIR"/AppDir/usr/bin/weasyprint <<\EOF
+      #! /bin/bash
+      set -eo pipefail
+      own_path="$(dirname "$(readlink -f "$0")")"
+      exec "$own_path"/../conda/bin/python -m weasyprint
+      EOF
+      chmod +x "$BUILD_DIR"/AppDir/usr/bin/weasyprint
+
 appimage:
   linuxdeploy:
     plugins:
       - qt
+      - conda
     environment:
       UPD_INFO: "gh-releases-zsync|dragotin|kraft|latest|Kraft-*x86_64.AppImage.zsync"
+      PIP_REQUIREMENTS: "weasyprint"

--- a/appimagecraft.yml
+++ b/appimagecraft.yml
@@ -1,0 +1,15 @@
+version: 1
+
+project:
+  name: de.volle_kraft_voraus.kraft.desktop
+  version_command: git describe --tags
+
+build:
+  cmake:
+
+appimage:
+  linuxdeploy:
+    plugins:
+      - qt
+    environment:
+      UPD_INFO: "gh-releases-zsync|dragotin|kraft|latest|Kraft-*x86_64.AppImage.zsync"


### PR DESCRIPTION
This PR implements automatic building of Kraft AppImages on GitHub actions using [appimagecraft](https://github.com/TheAssassin/appimagecraft).

The AppImage will contain weasyprint using [linuxdeploy-plugin-conda](https://github.com/linuxdeploy/linuxdeploy-plugin-conda), which is made available from `<AppDir>/usr/bin/weasyprint` (a simple shell script that calls weasyprint from the bundled miniconda environment). You need to adjust your code to also look for that binary. It wouldn't be a good idea to `export PATH`, and Qt makes it relatively simple to look up the own binary's location.

[pyuploadtool](https://github.com/TheAssassin/pyuploadtool) is used to upload AppImages built for commits the main branch (currently `master`) to a moving Git tag/prerelease called `continuous`. When tags are built, it automatically creates a release with the binaries. This is demonstrated [here](https://github.com/TheAssassin/kraft/releases/tag/continuous).

Overall, all of this is achieved with a minimum of code, the tools involved make it really simple.

Please note that openSUSE Leap 15.2 is most likely not a very good build platform. It is a relatively recent release, thus the resulting AppImage will most likely run only on recent distribution releases as well (>= Ubuntu bionic, according to [appimagelint](https://github.com/TheAssassin/appimagelint), but that remains to be proven in real world tests). Also, it's end-of-life and won't see updates any more. Overall, you may want to switch to, e.g., the oldest still-supported Ubuntu LTS release (18.04 aka bionic at the moment).