### PR TITLE
Fix artifacts upload for now

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,7 +60,7 @@ jobs:
     name: Create release and upload artifacts
     needs:
       - appimage-build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v2


### PR DESCRIPTION
libfuse2 is not available out of the box on 22.04, so we use 20.04.