### PR TITLE
Added Akonadi version check for some renamed components

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,7 +109,15 @@ set_package_properties(${AKO_PREFIX}AkonadiContact PROPERTIES
     TYPE OPTIONAL
 )
 
-if(${AKO_PREFIX}Akonadi_FOUND AND ${AKO_PREFIX}AkonadiContact_FOUND)
+find_package(${AKO_PREFIX}ContactEditor)
+set_package_properties(${AKO_PREFIX}ContactEditor PROPERTIES
+    DESCRIPTION "Library for editing contacts stored in Akonadi"
+    URL "https://www.kde.org/"
+    PURPOSE "Optionally used for addressbook integration"
+    TYPE OPTIONAL
+)
+
+if(${AKO_PREFIX}Akonadi_FOUND AND ${AKO_PREFIX}AkonadiContact_FOUND AND ${AKO_PREFIX}ContactEditor_FOUND)
    add_definitions(-DHAVE_AKONADI)
 endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -173,6 +173,7 @@ if(${AKO_PREFIX}Akonadi_FOUND)
   list(APPEND KRAFT_LINK_LIBS
     ${AKO_PREFIX}::AkonadiCore
     ${AKO_PREFIX}::AkonadiContact
+    ${AKO_PREFIX}::ContactEditor
     ${AKO_PREFIX}::AkonadiAgentBase
     ${AKO_PREFIX}::AkonadiWidgets
     ${AKO_PREFIX}::AkonadiXml

--- a/src/addressselectorwidget.cpp
+++ b/src/addressselectorwidget.cpp
@@ -410,7 +410,11 @@ void AddressSelectorWidget::slotEditContact()
     if ( index.isValid() ) {
       const Akonadi::Item item = index.data( Akonadi::EntityTreeModel::ItemRole ).value<Akonadi::Item>();
       if ( item.isValid() && item.hasPayload<KContacts::Addressee>() ) {
-        _addressEditor = new Akonadi::ContactEditorDialog(Akonadi::ContactEditorDialog::EditMode, this);
+#if AKONADICONTACT_VERSION >= QT_VERSION_CHECK(5, 24, 0)
+        _addressEditor = new ContactEditor::ContactEditorDialog(ContactEditor::ContactEditorDialog::EditMode, this );
+#else
+        _addressEditor = new Akonadi::ContactEditorDialog(Akonadi::ContactEditorDialog::CreateMode, this );
+#endif
         _addressEditor->setContact( item );
         _addressEditor->show();
       }

--- a/src/addressselectorwidget.cpp
+++ b/src/addressselectorwidget.cpp
@@ -235,7 +235,11 @@ KraftContactViewer::KraftContactViewer(QWidget *parent)
     lay->setMargin(0);
     setLayout(lay);
 #ifdef HAVE_AKONADI
+#if AKONADICONTACT_VERSION >= QT_VERSION_CHECK(5, 24, 0)
+    _contactViewer = new ContactEditor::ContactViewer;
+#else
     _contactViewer = new Akonadi::ContactViewer;
+#endif
     _contactViewer->setShowQRCode(false);
 
     lay->addWidget(_contactViewer);
@@ -372,9 +376,12 @@ bool AddressSelectorWidget::backendUp() const
 void AddressSelectorWidget::slotCreateNewContact()
 {
 #ifdef HAVE_AKONADI
-    // FIXME
-_addressEditor.reset(new Akonadi::ContactEditorDialog( Akonadi::ContactEditorDialog::CreateMode, this ));
-_addressEditor->show();
+#if AKONADICONTACT_VERSION >= QT_VERSION_CHECK(5, 24, 0)
+    _addressEditor = new ContactEditor::ContactEditorDialog(ContactEditor::ContactEditorDialog::EditMode, this );
+#else
+    _addressEditor = new Akonadi::ContactEditorDialog(Akonadi::ContactEditorDialog::CreateMode, this );
+#endif
+    _addressEditor->show();
 #endif
 }
 
@@ -398,13 +405,12 @@ void AddressSelectorWidget::slotAddresseeSelected(QModelIndex index)
 void AddressSelectorWidget::slotEditContact()
 {
 #ifdef HAVE_AKONADI
-
   if( _addressTreeView->selectionModel()->hasSelection() ) {
       QModelIndex index = _addressTreeView->selectionModel()->currentIndex();
     if ( index.isValid() ) {
       const Akonadi::Item item = index.data( Akonadi::EntityTreeModel::ItemRole ).value<Akonadi::Item>();
       if ( item.isValid() && item.hasPayload<KContacts::Addressee>() ) {
-        _addressEditor.reset(new Akonadi::ContactEditorDialog( Akonadi::ContactEditorDialog::EditMode, this ));
+        _addressEditor = new Akonadi::ContactEditorDialog(Akonadi::ContactEditorDialog::EditMode, this);
         _addressEditor->setContact( item );
         _addressEditor->show();
       }

--- a/src/addressselectorwidget.h
+++ b/src/addressselectorwidget.h
@@ -30,7 +30,10 @@
 #else
 #define AKONADICONTACT_VERSION AKONADI_VERSION
 #endif
-#if AKONADICONTACT_VERSION >= QT_VERSION_CHECK(5, 20, 0)
+#if AKONADICONTACT_VERSION >= QT_VERSION_CHECK(5, 24, 0)
+#include <AkonadiContactEditor/Akonadi/ContactViewer>
+#include <AkonadiContactEditor/Akonadi/ContactEditorDialog>
+#elif AKONADICONTACT_VERSION >= QT_VERSION_CHECK(5, 20, 0)
 #include <AkonadiContact/Akonadi/ContactViewer>
 #include <AkonadiContact/Akonadi/ContactEditorDialog>
 #else
@@ -66,7 +69,11 @@ class KraftContactViewer : public QWidget
 
 private:
 #ifdef HAVE_AKONADI
+#if AKONADICONTACT_VERSION >= QT_VERSION_CHECK(5, 24, 0)
+    ContactEditor::ContactViewer *_contactViewer;
+#else
     Akonadi::ContactViewer *_contactViewer;
+#endif
 #endif
 };
 
@@ -124,7 +131,11 @@ private:
   QTreeView *_addressTreeView;
   KraftContactViewer *_contactViewer;
 #ifdef HAVE_AKONADI
-  QScopedPointer<Akonadi::ContactEditorDialog> _addressEditor;
+#if AKONADICONTACT_VERSION >= QT_VERSION_CHECK(5, 24, 0)
+    ContactEditor::ContactEditorDialog *_addressEditor;
+#else
+    Akonadi::ContactEditorDialog *_addressEditor;
+#endif
 #endif
 };
 


### PR DESCRIPTION
This PR contains Akonadi version checks for components that were renamed in Akonadi version 5.24. Akonadi renamed the contact viewer and editors namespace.

With this PR, that should be automatically detected and build should work for version from 5.24 on but also older releases.

Note for old Akonadi that still has the KF5 instead of KPim5 prefix, cmake must be called with a build switch:
``` 
cmake -DAKONADI_LEGACY_BUILD=ON ..
```
See #209 