### PR TITLE
Omit `BUILD_HOST_NAME` for reproducible builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,11 @@ execute_process(
 )
 message("GIT_BRANCH: ${GIT_BRANCH}")
 
-cmake_host_system_information(RESULT BUILD_HOST_NAME QUERY HOSTNAME)
+if($ENV{SOURCE_DATE_EPOCH})
+    set(BUILD_HOST_NAME "reproduciblebuild")
+else ()
+    cmake_host_system_information(RESULT BUILD_HOST_NAME QUERY HOSTNAME)
+endif()
 if(${CMAKE_VERSION} VERSION_GREATER "3.22.0")
     cmake_host_system_information(RESULT BUILD_HOST_DISTRI QUERY DISTRIB_PRETTY_NAME)
 else ()


### PR DESCRIPTION
Distributions that want reproducible builds, set the `SOURCE_DATE_EPOCH`
environment variable. In this case, we should not record the build
host name to allow for bit-identical rebuilds elsewhere.

This PR was done while working on [reproducible builds for openSUSE](https://en.opensuse.org/openSUSE:Reproducible_Builds).