### PR TITLE
fixed I18N_ARGUMENT_MISSING string showing up in the error dialog;

### DIFF
--- a/src/reportgenerator.cpp
+++ b/src/reportgenerator.cpp
@@ -380,11 +380,13 @@ QString ReportGenerator::findTemplateFile( const QString& type )
         // check if file exists
         QFileInfo fi(tmplFile);
         if (!fi.isFile()) {
-            emit failure(i18n("The template file %1 for document type %2 does not exist.").arg(tmplFile).arg(dType.name()), "");
+            emit failure(i18nc("The template file %1 for document type %2 does not exist.", tmplFile.toLatin1().constData(),
+                dType.name().toLatin1().constData()), "");
             return QString();
         }
         if (!fi.isReadable()) {
-            emit failure(i18n("The template file %1 for document type %2 can not be read.").arg(tmplFile).arg(dType.name()), "");
+            emit failure(i18nc("The template file %1 for document type %2 can not be read.", tmplFile.toLatin1().constData(),
+                dType.name().toLatin1().constData()), "");
             return QString();
         }
     }


### PR DESCRIPTION
Hi Klaas,

this PR hopefully fixes the problem with the I18N_ARGUMENT_MISSING text showing up in the error dialog.
Completely untested - i do not even know if this compiles.

![Screenshot_20240212_184429](https://github.com/dragotin/kraft/assets/644248/26c8786e-3de4-45a0-9ae0-a08f92cb7977)

