### PR TITLE
t_defaultprovider: properly delete created file

### DIFF
--- a/tests/t_defaultprovider.cpp
+++ b/tests/t_defaultprovider.cpp
@@ -146,7 +146,7 @@ private slots:
             const QString noExistFile2 = DefaultProvider::self()->locateFile("nomydir/kraftfile");
             QVERIFY(noExistFile2.isEmpty());
 
-            QVERIFY(td.rmdir(mydir));
+            QVERIFY(fi.dir().removeRecursively());
 
         } else {
             qDebug() << "Skipped relative path test, directory share exists.";


### PR DESCRIPTION
rmdir() only deletes an empty directory. As files were created within this directory the test would always fail.
This wasn't showing as it would nearly always be skipped as the directory is still left over from the first failed run.