### PR TITLE
Use the non-legacy add_test() CMake command

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,67 +13,67 @@ set(test_libs Qt6::Test kraftlib)
 
 add_executable(t_unitman t_unitman.cpp)
 target_link_libraries(t_unitman ${test_libs})
-add_test(t_unitman t_unitman)
+add_test(NAME t_unitman COMMAND t_unitman)
 
 # ============================================================
 
 add_executable(t_format t_format.cpp)
-add_test(t_format t_format)
+add_test(NAME t_format COMMAND t_format)
 target_link_libraries(t_format ${test_libs})
 
 # ============================================================
 
 add_executable(t_metaparser t_metaparser.cpp)
-add_test(t_metaparser t_metaparser)
+add_test(NAME t_metaparser COMMAND t_metaparser)
 
 target_link_libraries(t_metaparser ${test_libs})
 
 # ============================================================
 
 add_executable(t_defaultprovider t_defaultprovider.cpp)
-add_test(t_defaultprovider t_defaultprovider)
+add_test(NAME t_defaultprovider COMMAND t_defaultprovider)
 
 target_link_libraries(t_defaultprovider ${test_libs})
 
 # ============================================================ 
 
 add_executable(t_doctype t_doctype.cpp)
-add_test(t_doctype t_doctype)
+add_test(NAME t_doctype COMMAND t_doctype)
 
 target_link_libraries(t_doctype ${test_libs})
 
 # ============================================================
 
 add_executable(t_numbercycle t_numbercycle.cpp)
-add_test(t_numbercycle t_numbercycle)
+add_test(NAME t_numbercycle COMMAND t_numbercycle)
 
 target_link_libraries(t_numbercycle ${test_libs})
 
 # ============================================================
 
 add_executable(t_attributes t_attributes.cpp)
-add_test(t_attributes t_attributes)
+add_test(NAME t_attributes COMMAND t_attributes)
 
 target_link_libraries(t_attributes ${test_libs})
 
 # ============================================================
 
 add_executable(t_stringutil t_stringutil.cpp)
-add_test(t_stringutil t_stringutil)
+add_test(NAME t_stringutil COMMAND t_stringutil)
 
 target_link_libraries(t_stringutil ${test_libs})
 
 # ============================================================
 
 add_executable(t_kraftdoc t_kraftdoc.cpp)
-add_test(t_kraftdoc t_kraftdoc)
+add_test(NAME t_kraftdoc COMMAND t_kraftdoc)
 
 target_link_libraries(t_kraftdoc ${test_libs})
 
 # ============================================================
 
 add_executable(t_docposition t_docposition.cpp)
-add_test(t_docposition t_docposition)
+add_test(NAME t_docposition COMMAND t_docposition)
 
 target_link_libraries(t_docposition ${test_libs})
 
@@ -86,28 +86,28 @@ configure_file ("testconfig.h.in" "testconfig.h")
 # ============================================================
 
 add_executable(t_xmlsaver t_xmlsaver.cpp)
-add_test(t_xmlsaver t_xmlsaver)
+add_test(NAME t_xmlsaver COMMAND t_xmlsaver)
 
 target_link_libraries(t_xmlsaver ${test_libs})
 
 # ============================================================
 
 add_executable(t_xmldocindex t_xmldocindex.cpp)
-add_test(t_xmldocindex t_xmldocindex)
+add_test(NAME t_xmldocindex COMMAND t_xmldocindex)
 
 target_link_libraries(t_xmldocindex ${test_libs})
 
 # ============================================================
 
 add_executable(t_kraftattrib t_kraftattrib.cpp)
-add_test(t_kraftattrib t_kraftattrib)
+add_test(NAME t_kraftattrib COMMAND t_kraftattrib)
 
 target_link_libraries(t_kraftattrib ${test_libs})
 
 # ============================================================
 
 add_executable(t_jsonindexfile t_jsonindexfile.cpp)
-add_test(t_jsonindexfile t_jsonindexfile)
+add_test(NAME t_jsonindexfile COMMAND t_jsonindexfile)
 
 target_link_libraries(t_jsonindexfile ${test_libs})
 


### PR DESCRIPTION
Use the `add_test()` command with explicit `NAME` and `COMMAND` options; this syntax uses the proper location for the test executable instead of relying on an explicit path.

This fixes the execution of the test suite.