### PR TITLE
Extract Git info at build time only if possible

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,14 +21,27 @@ set(AKO_PREFIX "KPim6")
 
 message("Akonadi Prefix is ${AKO_PREFIX}")
 
-include(GetGitRevisionDescription)
+find_package(Git QUIET)
+if (Git_FOUND AND EXISTS "${CMAKE_SOURCE_DIR}/.git")
+    include(GetGitRevisionDescription)
 
-# set git revision info
-get_git_head_revision(GIT_REFSPEC GIT_SHA1)
-# if we cannot get it from git, directly try .tag (packages)
-# this will work if the tar balls have been properly created
-# via git-archive.
-if ("${GIT_SHA1}" STREQUAL "GITDIR-NOTFOUND")
+    # set git revision info
+    get_git_head_revision(GIT_REFSPEC GIT_SHA1)
+
+    execute_process(
+      COMMAND git rev-parse --abbrev-ref HEAD
+      WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+      OUTPUT_VARIABLE GIT_BRANCH
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+
+    message(STATUS "Git dynamic information")
+    message("GIT_SHA1: ${GIT_SHA1}")
+    message("GIT_BRANCH: ${GIT_BRANCH}")
+else()
+    # if we cannot get it from git, directly try .tag (packages)
+    # this will work if the tar balls have been properly created
+    # via git-archive.
     if (EXISTS "${CMAKE_SOURCE_DIR}/.tag")
         file(READ ${CMAKE_SOURCE_DIR}/.tag sha1_candidate)
         string(REPLACE "\n" "" sha1_candidate ${sha1_candidate})
@@ -39,18 +52,8 @@ if ("${GIT_SHA1}" STREQUAL "GITDIR-NOTFOUND")
     else()
         set (GIT_SHA1 "unknown")
     endif()
+    set(GIT_BRANCH "${GIT_SHA1}")
 endif()
-
-message(STATUS "Git dynamic information")
-message("GIT_SHA1: ${GIT_SHA1}")
-
-execute_process(
-  COMMAND git rev-parse --abbrev-ref HEAD
-  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-  OUTPUT_VARIABLE GIT_BRANCH
-  OUTPUT_STRIP_TRAILING_WHITESPACE
-)
-message("GIT_BRANCH: ${GIT_BRANCH}")
 
 if($ENV{SOURCE_DATE_EPOCH})
     set(BUILD_HOST_NAME "reproduciblebuild")


### PR DESCRIPTION
The build system tries to extract some Git build details (e.g. branch and SHA). The problem is that it assumes that both `git` is installed, and that the sources are in a Git repository: while this is true during a Git build, they are both not true when building from release tarballs (e.g. as done by distributions).

Hence, manually search for `git` and that the current sources are a Git repository:
- if both are valid, extract the build details as done so far
- if neither is available, still try to use `.tag` for the SHA, setting the value for the branch as well to it