### PR TITLE
Typo fixes

### DIFF
--- a/Changes.txt
+++ b/Changes.txt
@@ -59,8 +59,8 @@ Changes since version 1.1: #########################################
 - Manual: Updated screenshots for all languages
 - Fix #211: Be more robust if no .git file is there
 - Fix cmake warnings
-- Substancial code cleanups
-- Fix reproducable builds
+- Substantial code cleanups
+- Fix reproducible builds
 - Fix saving of XRechnung files
 - Added a template for XRechnung version 3.0.1
 - Fix #218: Add a image mask for reportlab
@@ -133,7 +133,7 @@ Changes since version 0.97: #########################################
 - Fix: Use correct icons everywhere.
 - Fix: Format of date and time corrected.
 - Fix: Store useful value for the locale in db. For later.
-- Fix: Textselection behaviour consitent
+- Fix: Textselection behaviour consistent
 - Fix: Write useful locale settings into the database.
 - Fix: Sorting in material catalogue now working.
 - Fix: Better error messages if python modules are missing.
@@ -199,7 +199,7 @@ Changes since version 0.82: #########################################
 - Reworked follow up and copy document
   * set the correct header- and footer-texts according to the doc type
   * Added a checkbox if items should be copied or not
-- New feature: partial invoices that are substracted in the final invoice
+- New feature: partial invoices that are subtracted in the final invoice
 - Use an XML based migration system for document types
 - Added the first unit tests to Kraft
 - Made the document templates not containing any language specific
@@ -288,7 +288,7 @@ Changes since version 0.55: #########################################
    depending on the new document id
  - Fix behaviour of the greeting combobox: Do not loose custom entries
    any more
- - Add receipient email address if document is emailed
+ - Add recipient email address if document is emailed
  - Fix document emailing for thunderbird
  - Fix removing of alternative- and on-demand state of items
  - Wording fixes
@@ -305,7 +305,7 @@ Changes since version 0.54: #########################################
     => release v. 0.55 (may 29, 2014)
 
 Changes since version 0.53: #########################################
-- Use new address fetch job implementation that works independant
+- Use new address fetch job implementation that works independent
   from Nepomuk- or Baloo indexing of contacts. (KDE >= 4.12)
 - Support note-of-delivery documents (Lieferscheine) without prices.
 - Added findcontact utility
@@ -472,7 +472,7 @@ Changes since version 0.24: #########################################
 - Improved the document overview widget for more intuitive use.
 - Copying of complete documents added.
 - Followup documents (eg. Invoice follows Offer) added
-- Litte marker for new documents added to doc overview list.
+- Little marker for new documents added to doc overview list.
 - Help text added to positions canvas
 - Client address bits added to the available template variables
 
@@ -517,7 +517,7 @@ Changes since version 0.14: #########################################
   in the qt3 mysql driver the char needs to be en- and decoded.
 - reduced the amount of toolbar buttons to only show the important
   ones.
-- more beautifull and working navigation block in the document dialog
+- more beautiful and working navigation block in the document dialog
 - mailing documents added
 - Completely changed header- and footer text template system:
   * now there is more than one text available per text- and doc type

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -95,7 +95,7 @@ on first start. Its use is recommended for all users who
 want to evaluate Kraft.
 
 To run Kraft with MySQL, create or pick a user on the MySQL
-server with appropiate permissions to write to a specific
+server with appropriate permissions to write to a specific
 database and create tables on it. Create an empty database
 to use with Kraft. Remember both the database name and the
 credentials.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ template items. It focuses on high quality printouts because paper is
 still the main communication media in the small business world. However,
 it also sends documents via email and supports electronic invoicing with XRechnung.
 
-Kraft utilizes very useful tools of the free softare world:
+Kraft utilizes very useful tools of the free software world:
 - KDE addressbook for customer management
 - MySQL or alternatively SQLite for database support
 - [WeasyPrint](https://weasyprint.org) for PDF generation.

--- a/Releasenotes.txt
+++ b/Releasenotes.txt
@@ -29,7 +29,7 @@ das Update geschieht automatisch durch Kraft.
 ----------------------------------------------------------------------
 
 The Kraft release 0.22 changes the text template system that is 
-used by Kraft to support user configureable pdf output. It was
+used by Kraft to support user configurable pdf output. It was
 changed from a very basic homegrown system to the google ctemplate
 system, details under http://code.google.com/p/google-ctemplate/
 It is very flexible and mature and thus future proof which was
@@ -44,7 +44,7 @@ a position where it is not yet clear if and how much of it is needed.
 Both position kinds do not add to overall sum and are marked through
 italic characters in the printout by default.
 
-Furthermore a lot of bugfixes and genral code improvements where 
+Furthermore a lot of bugfixes and general code improvements where 
 committed. The database scheme was extended, update is automatically
 performed.
 

--- a/database/README
+++ b/database/README
@@ -23,7 +23,7 @@ The standard way however to let Kraft create and maintain
 the database schema for you. All that needs to be done 
 is to 
  - start MySQL on the system
- - have a user and password combination that has acces to
+ - have a user and password combination that has access to
    the database
  - create an empty database with a suitable name like for 
    example "kraft".

--- a/database/mysql/migration/2_dbmigrate.sql
+++ b/database/mysql/migration/2_dbmigrate.sql
@@ -1,4 +1,4 @@
-# message: Creating document position calulation tables ;
+# message: Creating document position calculation tables ;
 
 CREATE TABLE DocCalcTime (
 	TCalcID       INT NOT NULL AUTO_INCREMENT,

--- a/database/mysql/migration/5_dbmigrate.sql
+++ b/database/mysql/migration/5_dbmigrate.sql
@@ -18,7 +18,7 @@ CREATE TABLE archPosAttribs (
   PRIMARY KEY( archPosAttribId )
 );
 
-# message Adding position type and overall price ot archdocpositions
+# message Adding position type and overall price to archdocpositions
 ALTER TABLE archdocpos ADD COLUMN kind VARCHAR(64) AFTER ordNumber;
 ALTER TABLE archdocpos ADD COLUMN overallPrice DECIMAL(10,2) AFTER price;
 

--- a/database/sqlite3/migration/2_dbmigrate.sql
+++ b/database/sqlite3/migration/2_dbmigrate.sql
@@ -1,4 +1,4 @@
--- message: Creating document position calulation tables ;
+-- message: Creating document position calculation tables ;
 
 CREATE TABLE DocCalcTime (
 	TCalcID       INTEGER PRIMARY KEY ASC autoincrement,

--- a/database/sqlite3/migration/5_dbmigrate.sql
+++ b/database/sqlite3/migration/5_dbmigrate.sql
@@ -20,7 +20,7 @@ CREATE TABLE archPosAttribs (
 );
 
 -- Columns already added in create_schema.sql   *sqlite workaround*
--- message Adding position type and overall price ot archdocpositions
+-- message Adding position type and overall price to archdocpositions
 --ALTER TABLE archdocpos ADD COLUMN kind VARCHAR(64); -- AFTER ordNumber;
 --ALTER TABLE archdocpos ADD COLUMN overallPrice DECIMAL(10,2); -- AFTER price;
 

--- a/manual/images/en/kraft.adoc
+++ b/manual/images/en/kraft.adoc
@@ -45,7 +45,7 @@ During the initial setup you are asked to select a database to use and give the 
 
 You can fill in your company address (that appears on the printed documents) in two ways: in the setup procedure use the first tab *Select from Addressbook* for to select your on address in KAddressBook (if you have filled your own address in KaddressBook) or use the second tab *Manual entry* for to fill in the information of the address from your company manually. This step is necessary for the correct generation of your documents as the address is automatically used in the document generation step.
 
-image:company_adress1_EN.png[Company adress,float="right"]
+image:company_adress1_EN.png[Company address,float="right"]
 
 After the initial setup, select menu:Preferences[Settings].
 That allows to prepare Kraft correctly so it can be used in a proper way.
@@ -73,7 +73,7 @@ At the first use you find a list of different document types, such as:
 image:documentype_EN.png[Document type,float="right"]
 
 Translate this types to your own language.
-You can also add new ones and remove document types you wont use.
+You can also add new ones and remove document types you won't use.
 
 ==== Numbercycles
 
@@ -144,7 +144,7 @@ All data can be edited, customized and new items can be added in the
 Kraft Configuration Dialog reachable through the Settings menu.
 
 Remember that these units are later used in the documents, it is
-therefor important that you translate them to your own language and to
+therefore important that you translate them to your own language and to
 fill in the correct prices.
 
 === Units of measurement
@@ -154,7 +154,7 @@ A list of units of measurement is maintained in Kraft. In Kraft Configuration Di
 list, and also can you add new items to the list.
 
 Remember that these units are later used in the documents, it is
-therefor important that you translate them to your own language.
+therefore important that you translate them to your own language.
 
 === Own identity
 
@@ -177,7 +177,7 @@ the main window.Here we see three tabs:
 
 == Catalogs
 
-Kraft supports so called Catalogs in which templates for document items are kept. With the catalogs creating documents can be significantly accellerated in the day to day business. When creating new documents, the items templates from the catalogs can easily selected and moved over to the document.
+Kraft supports so called Catalogs in which templates for document items are kept. With the catalogs creating documents can be significantly accelerated in the day to day business. When creating new documents, the items templates from the catalogs can easily selected and moved over to the document.
 
 Since templates are organized in chapters entire documents can be prepared in different chapters to be used as template documents.
 
@@ -518,7 +518,7 @@ the window [create new item] opens.
 
 We want that the client can make a choice from an apple, a pear tree and the liguster.
 
-Therefor we are going to add also a pear tree manually.
+Therefore we are going to add also a pear tree manually.
 
 We click on the button btn:[Add item…] and the window [create new item] opens.
 
@@ -526,7 +526,7 @@ We fill here in the name of the tree `Pear tree`, at the field insert we
 fill in the number of the special trees that we have delivered and the
 price of them.
 
-We want add this to the material catalog for future use, therefor we
+We want add this to the material catalog for future use, therefore we
 select also [select this item as template for future documents] and we select in [save in chapter]`trees`.
 
 Click on btn:[OK] for saving the result or on btn:[Cancel] for discarding the
@@ -568,7 +568,7 @@ image:context2_EN.png[Context menu,float="right"]
 Click on btn:[OK] for saving the result or on btn:[Cancel] for discarding the
 result.
 
-We want to see the result and therefor we click on the button [show
+We want to see the result and therefore we click on the button [show
 document].
 
 We see now that the prize of the pear tree, the liguster and the removal
@@ -587,7 +587,7 @@ The document type "Acceptance of Order" is sent subsequently to an offer.
 
 image:acceptance_o_o_context.png[Numbercycles,float="right"]
 
-When a client has made a request, we will send an offer in wich we describe which items we will deliver.
+When a client has made a request, we will send an offer in which we describe which items we will deliver.
 Hopefully the client will give an order for the work.
 
 It is a good practice to respond on the order with an "Acceptance of order" in which we describe all the items we will deliver.
@@ -716,7 +716,7 @@ The syntax is based on the Django syntax for templates described in the https://
  are shown.
 [[configure]]
  [Settings]>[Configure Kraft]
- [Ctrl]+[Shft]+[,]
+ [Ctrl]+[Shift]+[,]
  Here you can configure Kraft.
 
 === Document Edit Window
@@ -821,7 +821,7 @@ Once the file is adopted to the needs, open the Settings dialog of Kraft and ins
 
 After that step, the btn:[Export XRechung] menu item will open a dialog to pick a filename where to save the XRechnung invoice to.
 
-This file can now be transfered to the receiver of the invoice.
+This file can now be transferred to the receiver of the invoice.
 
 NOTE: There are validators for invoices in XRechnung format out there in the internet. It is useful to verify the  format of the Kraft exported XRechnung.
 

--- a/manual/kraft.adoc
+++ b/manual/kraft.adoc
@@ -50,7 +50,7 @@ You can fill in your company address (that appears on the printed documents) in 
 
 To generate the EPC QR Code that can be printed on the output document, the bank account details need to be added as well.
 
-image:company_adress1.png[Company adress,float="right"]
+image:company_adress1.png[Company address,float="right"]
 
 After the initial setup, select menu:Preferences[Settings].
 That allows to prepare Kraft correctly for individual needs.
@@ -78,7 +78,7 @@ At the first use you find a list of different document types, such as:
 image:documentype.png[Document type,float="right"]
 
 Translate this types to your own language.
-You can also add new ones and remove document types you wont use.
+You can also add new ones and remove document types you won't use.
 
 ==== Numbercycles
 
@@ -176,7 +176,7 @@ All data can be edited, customized and new items can be added in the
 Kraft Configuration Dialog reachable through the Settings menu.
 
 Remember that these units are later used in the documents, it is
-therefor important that you translate them to your own language and to
+therefore important that you translate them to your own language and to
 fill in the correct prices.
 
 === Units of measurement
@@ -186,7 +186,7 @@ A list of units of measurement is maintained in Kraft. In Kraft Configuration Di
 list, and also can you add new items to the list.
 
 Remember that these units are later used in the documents, it is
-therefor important that you translate them to your own language.
+therefore important that you translate them to your own language.
 
 === Own identity
 
@@ -208,7 +208,7 @@ After the configuration is finalized, we go back to the main window which consis
 
 == Catalogs
 
-Kraft supports so called Catalogs in which templates for document items are kept. With the catalogs creating documents can be significantly accellerated in the day to day business. When creating new documents, the items templates from the catalogs can easily selected and moved over to the document.
+Kraft supports so called Catalogs in which templates for document items are kept. With the catalogs creating documents can be significantly accelerated in the day to day business. When creating new documents, the items templates from the catalogs can easily selected and moved over to the document.
 
 Since templates are organized in chapters entire documents can be prepared in different chapters to be used as template documents.
 
@@ -592,7 +592,7 @@ the window [create new item] opens.
 
 We want that the client can make a choice from an apple, a pear tree and the liguster.
 
-Therefor we are going to add also a pear tree manually.
+Therefore we are going to add also a pear tree manually.
 
 We click on the button btn:[Add item…] and the window [create new item] opens.
 
@@ -600,7 +600,7 @@ We fill here in the name of the tree `Pear tree`, at the field insert we
 fill in the number of the special trees that we have delivered and the
 price of them.
 
-We want add this to the material catalog for future use, therefor we
+We want add this to the material catalog for future use, therefore we
 select also [select this item as template for future documents] and we select in [save in chapter]`trees`.
 
 Click on btn:[OK] for saving the result or on btn:[Cancel] for discarding the
@@ -642,7 +642,7 @@ image:context2.png[Context menu,float="right"]
 Click on btn:[OK] for saving the result or on btn:[Cancel] for discarding the
 result.
 
-We want to see the result and therefor we click on the button [show
+We want to see the result and therefore we click on the button [show
 document].
 
 We see now that the prize of the pear tree, the liguster and the removal
@@ -661,7 +661,7 @@ The document type "Acceptance of Order" is sent subsequently to an offer.
 
 image:acceptance_o_o_context.png[Numbercycles,float="right"]
 
-When a client has made a request, we will send an offer in wich we describe which items we will deliver.
+When a client has made a request, we will send an offer in which we describe which items we will deliver.
 Hopefully the client will give an order for the work.
 
 It is a good practice to respond on the order with an "Acceptance of order" in which we describe all the items we will deliver.
@@ -702,7 +702,7 @@ Information Management) software collection of https://www.kde.org[KDE]. Integra
 recommendation and default of Kraft.
 
 However, in some situations the KAddressBook Integration can not be set up. In that cases, Kraft can also read
-a address collection of a local directory. The directory can be set in the Kraft config file in group `[KraftV2]`, key `KraftV2AddressDir`. If not explicitely set, it defaults
+a address collection of a local directory. The directory can be set in the Kraft config file in group `[KraftV2]`, key `KraftV2AddressDir`. If not explicitly set, it defaults
 to `$HOME/.local/share/contacts`.
 
 This directory needs to contain single files in the vCard format, with file extension `.vcf`. All these files are
@@ -759,7 +759,7 @@ On the PDF output it is nice to have a logo image included, if the documents sho
 
 This chapter describes a few methods to achieve that with the weasyprint based template.
 
-===== PDF Watermark Funktionality
+===== PDF Watermark Functionality
 
 The first, and easiest way to add a logo and other details on the print out is to use the so called PDF Watermark option.
 
@@ -917,7 +917,7 @@ To include the generated EPC QR Code into the PDF document, the Weasyprint templ
  are shown.
 [[configure]]
  [Settings]>[Configure Kraft]
- [Ctrl]+[Shft]+[,]
+ [Ctrl]+[Shift]+[,]
  Here you can configure Kraft.
 
 === Document Edit Window

--- a/reports/contrib/bnc-ng/bnc-global.css
+++ b/reports/contrib/bnc-ng/bnc-global.css
@@ -359,7 +359,7 @@
 
   .totals {
     width: 165mm;
-/*  table-layout: fixed; /* this somehow adds 2mm horizontal spacing and messes everyting up */
+/*  table-layout: fixed; /* this somehow adds 2mm horizontal spacing and messes everything up */
     vertical-align: top;
     line-height: 1.25;
     box-sizing: border-box;
@@ -537,7 +537,7 @@
 
 /* A perverse invention by Google: There is a browser built-in CSS style
  * sheet defining certain settings "to make the web look like it should".
- * The worst part are implicit margin settigs that affect any element
+ * The worst part are implicit margin settings that affect any element
  * without "position: absolute;". While this might be a good idea for a web
  * browser it makes print layout an educated guess.
  */

--- a/reports/contrib/bnc/bnc-global.css
+++ b/reports/contrib/bnc/bnc-global.css
@@ -341,7 +341,7 @@
 
   .totals {
     width: 165mm;
-/*  table-layout: fixed; /* this somehow adds 2mm horizontal spacing and messes everyting up */
+/*  table-layout: fixed; /* this somehow adds 2mm horizontal spacing and messes everything up */
     vertical-align: top;
     line-height: 1.25;
     box-sizing: border-box;
@@ -497,7 +497,7 @@
 
 /* A perverse invention by Google: There is a browser built-in CSS style
  * sheet defining certain settings "to make the web look like it should".
- * The worst part are implicit margin settigs that affect any element
+ * The worst part are implicit margin settings that affect any element
  * without "position: absolute;". While this might be a good idea for a web
  * browser it makes print layout an educated guess.
  */

--- a/reports/contrib/debug/README.md
+++ b/reports/contrib/debug/README.md
@@ -1,5 +1,5 @@
 This debug template displays all available template variables
-including their value of the current docuemnt.
+including their value of the current document.
 
 Very useful to understand which variables are available.
 

--- a/reports/contrib/debug/debug.css
+++ b/reports/contrib/debug/debug.css
@@ -237,7 +237,7 @@
 
   .totals {
     width: 165mm;
-/*  table-layout: fixed; /* this somehow adds 2mm horizontal spacing and messes everyting up */
+/*  table-layout: fixed; /* this somehow adds 2mm horizontal spacing and messes everything up */
     vertical-align: top;
     line-height: 1.25;
     box-sizing: border-box;
@@ -415,7 +415,7 @@
 
 /* A perverse invention by Google: There is a browser built-in CSS style
  * sheet defining certain settings "to make the web look like it should".
- * The worst part are implicit margin settigs that affect any element
+ * The worst part are implicit margin settings that affect any element
  * without "position: absolute;". While this might be a good idea for a web
  * browser it makes print layout an educated guess.
  */

--- a/src/attribute.cpp
+++ b/src/attribute.cpp
@@ -232,7 +232,7 @@ void AttributeMap::save( dbID id )
         }
       }
     } else {
-      // only a single entry for the attribte, update if needed.
+      // only a single entry for the attribute, update if needed.
       QString newValue = att.mValue.toString();  // access the attribute object directly to get the numeric
       // qDebug () << "NEW value String: " << newValue;
       // value in case the attribute is bound to a relation table

--- a/src/calctemplate.ui
+++ b/src/calctemplate.ui
@@ -196,7 +196,7 @@
          <item>
           <widget class="QLabel" name="textLabel2">
            <property name="text">
-            <string>Time measureable effort for this template:</string>
+            <string>Time measurable effort for this template:</string>
            </property>
            <property name="wordWrap">
             <bool>false</bool>

--- a/src/catalogchapter.cpp
+++ b/src/catalogchapter.cpp
@@ -1,5 +1,5 @@
 /***************************************************************************
-             catalogchapter.h  - a simle catalog chapter object
+             catalogchapter.h  - a simple catalog chapter object
                              -------------------
     begin                : Thu Nov 4 2010
     copyright            : (C) 2010 by Klaas Freitag
@@ -145,5 +145,5 @@ void CatalogChapter::reparent( const dbID& pId )
   q.bindValue(":id", mId.toInt() );
   q.bindValue(":p", parentId.toInt() );
   q.exec();
-  // qDebug () << "Reparenting chapter " << mId.toInt() << ", reuslt: " << q.lastError().text();
+  // qDebug () << "Reparenting chapter " << mId.toInt() << ", result: " << q.lastError().text();
 }

--- a/src/catalogchapter.h
+++ b/src/catalogchapter.h
@@ -1,5 +1,5 @@
 /***************************************************************************
-             catalogchapter.h  - a simle catalog chapter object
+             catalogchapter.h  - a simple catalog chapter object
                              -------------------
     begin                : Thu Nov 4 2010
     copyright            : (C) 2010 by Klaas Freitag

--- a/src/dbtoxmlconverter.cpp
+++ b/src/dbtoxmlconverter.cpp
@@ -90,7 +90,7 @@ QMap<QByteArray, int> DbToXMLConverter::convert(const QString& dBase)
     overallResults["numberCyclesOk"] = nc_cnt;
     Q_EMIT conversionOut(i18n("<br/>Transformed %1 numbercycle(s) successfully.").arg(nc_cnt));
     for( const auto& k : overallResults.keys()) {
-        qDebug() << "Tranformation result" << k << ":" << overallResults[k];
+        qDebug() << "Transformation result" << k << ":" << overallResults[k];
     }
 
     if (convertOwnIdentity(dBase)) {

--- a/src/docposition.cpp
+++ b/src/docposition.cpp
@@ -94,7 +94,7 @@ int DocPosition::taxTypeNumeric()
     else if ( mTaxType == Tax::Full )
         return 3;
 
-    // qDebug () << "ERR: Vat-type ambigous!";
+    // qDebug () << "ERR: Vat-type ambiguous!";
     return 0; // Invalid
 }
 

--- a/src/doctype.cpp
+++ b/src/doctype.cpp
@@ -485,7 +485,7 @@ bool DocType::isXRechnungEnabled() const
 }
 
 /*
- * Saves the name and the attriutes (numbercycle, demand, etc.)
+ * Saves the name and the attributes (numbercycle, demand, etc.)
  */
 void DocType::save()
 {

--- a/src/documentman.cpp
+++ b/src/documentman.cpp
@@ -74,7 +74,7 @@ DocGuardedPtr DocumentMan::createDocument( const QString& docType, const QString
 
             // check for relations between old and new doc
             DocType sourceDocType( sourceDoc->docType() );
-            // for new docs check if it should substract the sum of the predecessor doc
+            // for new docs check if it should subtract the sum of the predecessor doc
             DocType newDocType(docType);
             if( newDocType.substractPartialInvoice() ) {
                 if( sourceDocType.partialInvoice()  ) {
@@ -87,10 +87,10 @@ DocGuardedPtr DocumentMan::createDocument( const QString& docType, const QString
                         Geld ng(-1 * g.toLong());
 
                         pos->setUnitPrice(ng);
-                        pos->setText(i18nc("Text to be inserted into a doc, if the sum of another doc needs to be substracted "
+                        pos->setText(i18nc("Text to be inserted into a doc, if the sum of another doc needs to be subtracted "
 					   "ie. in a final invoice if there was a partial invoice before"
 					   "%1 is substited by the doc type, %2 by the id of the predecessor doc.",
-					   "Substract sum from %1 %2",
+					   "Subtract sum from %1 %2",
                                           sourceDocType.name(), sourceDoc->docIdentifier()));
                     }
                 }

--- a/src/documentsaverxml.cpp
+++ b/src/documentsaverxml.cpp
@@ -207,7 +207,7 @@ QDomDocument xmlDocument(KraftDoc *doc)
 
     headerElem.appendChild( textElement( xmldoc, "salut", doc->salut()));
     headerElem.appendChild( textElement( xmldoc, "preText", doc->preText()));
-    // FIXME: add Header attributs
+    // FIXME: add Header attributes
 
     // **** Next toplevel: itemGroup, for now only one
     QDomElement itemGroupElem = xmldoc.createElement( "itemGroup" );
@@ -606,7 +606,7 @@ bool DocumentSaverXML::saveDocument(KraftDoc *doc)
 
     // qDebug () << "Saved document no " << doc->docID().toString() << endl;
     if (newState) {
-        // retore the new state in the doc for subsequent funcs - no idea which ones...
+        // restore the new state in the doc for subsequent funcs - no idea which ones...
         doc->state().setState(KraftDocState::State::New);
     }
 

--- a/src/extractrc
+++ b/src/extractrc
@@ -277,7 +277,7 @@ for my $file_name ( @ARGV )
              push @atts, [$ectx_att, $aval];
            }
          }
-         # Kill all tags in element-context with level higer or equal to this,
+         # Kill all tags in element-context with level higher or equal to this,
          # and add it to the end.
          my $clevel = ECTX_SPEC->{$ectx_ext}{$tag}[0];
          for ( my $i = 0; $i < @ectx; ++$i )
@@ -384,7 +384,7 @@ for my $file_name ( @ARGV )
              for my $agr ( @{$tgr->[2]} )
              {
                #push @attr_gr, "$agr->[0]=$agr->[1]";
-               push @attr_gr, "$agr->[1]"; # no real nead for attribute name
+               push @attr_gr, "$agr->[1]"; # no real need for attribute name
              }
              my $attr = join(", ", @attr_gr);
              push @tag_gr, "$tgr->[1] ($attr)" if $attr;

--- a/src/jsonindexfile.h
+++ b/src/jsonindexfile.h
@@ -28,7 +28,7 @@ class DocDigest;
 class QFileInfo;
 
 /**
- * @brief JsonIndexFile - simple persistance of the document index
+ * @brief JsonIndexFile - simple persistence of the document index
  *
  */
 

--- a/src/katalogview.h
+++ b/src/katalogview.h
@@ -48,8 +48,8 @@ class KRAFTCAT_EXPORT KatalogView : public QMainWindow
   Q_OBJECT
 
   public:
-    /** construtor of a catalog view.
-     * Note: init must be called immediately after instanciating a inherited
+    /** constructor of a catalog view.
+     * Note: init must be called immediately after instantiating a inherited
      * class of KatalogView
      */
     KatalogView(QWidget* parent=0, const char* name=0);
@@ -121,7 +121,7 @@ protected Q_SLOTS:
 
     /** initializes the QActions of the application */
     void initActions();
-    /** sets up the statusbar for the main window by initialzing a statuslabel.
+    /** sets up the statusbar for the main window by initializing a statuslabel.
      */
 
     /** initializes the document object of the main window that is connected to the view in initView().

--- a/src/kraftdb.cpp
+++ b/src/kraftdb.cpp
@@ -585,7 +585,7 @@ bool KraftDB::checkTableExistsSqlite(const QString& name, const QStringList& loo
 
     while( q.next() ) {
         const QString colName = q.value(1).toString();
-        qDebug() << "checking colum" << colName;
+        qDebug() << "checking column" << colName;
         cols.removeAll(colName);
     }
     return cols.isEmpty();

--- a/src/kraftdb.h
+++ b/src/kraftdb.h
@@ -75,7 +75,7 @@ public:
   bool databaseExists();
 
   /*
-   * required and current schema versions. Must be equal for a healty
+   * required and current schema versions. Must be equal for a healthy
    * Kraft database. If currentSchemaVersion is smaller than requiredSchemaVersion,
    * the db needs an update.
    */

--- a/src/kraftview.cpp
+++ b/src/kraftview.cpp
@@ -1186,7 +1186,7 @@ DocPositionList KraftView::currentPositionList()
                             }
                         } else {
                             // we cannot calculate ourselves.
-                            // qDebug () << "Skipping pos " << w1->ordNumber() << " in summing up, thats me!";
+                            // qDebug () << "Skipping pos " << w1->ordNumber() << " in summing up, that's me!";
                         }
                     }
                     // qDebug () << "Finished loop over items with calculatable=" << calculatable;

--- a/src/materialkataloglistview.cpp
+++ b/src/materialkataloglistview.cpp
@@ -65,7 +65,7 @@ void MaterialKatalogListView::addCatalogDisplay( const QString& katName )
     // qDebug () << "No catalog in listview available!";
     return;
   }
-  // qDebug () << "setting up meterial chapters --------*********************************+++!";
+  // qDebug () << "setting up material chapters --------*********************************+++!";
   setupChapters();
 
   // lambda expression to be DRY

--- a/src/materialtempldialog.cpp
+++ b/src/materialtempldialog.cpp
@@ -214,7 +214,7 @@ void MaterialTemplDialog::accept()
     // qDebug () << "Setting unit id "  << u;
     mSaveMaterial->setUnitId( u );
 
-    // chapId = 0; // FIXME: get a chapter catalog Id of hirarchical
+    // chapId = 0; // FIXME: get a chapter catalog Id of hierarchical
     mSaveMaterial->setChapter( mChapId );
 
     double db = mInPurchasePrice->value();

--- a/src/metaxmlparser.cpp
+++ b/src/metaxmlparser.cpp
@@ -35,7 +35,7 @@ bool MetaXMLParser::parse( QIODevice *device )
     _docTypeAddList.clear();
 
     if (!_domDocument.setContent(device, true, &_errorString, &_errorLine, &_errorColumn)) {
-        qDebug() << "Not able to parse XML: " << _errorString << "Line"<< _errorLine << ", Colum" << _errorColumn;
+        qDebug() << "Not able to parse XML: " << _errorString << "Line"<< _errorLine << ", Column" << _errorColumn;
         return false;
     }
 

--- a/src/models/contactsdirmodel.cpp
+++ b/src/models/contactsdirmodel.cpp
@@ -109,7 +109,7 @@ ContactsDirModel::ContactsDirModel(const QString& baseDir, QObject *parent)
     rootAdr.setFormattedName(baseDir);
     _rootItem = std::make_unique<CTMItem>(rootAdr);
 
-    // FIXME: SHould this rather happpen in the addressproviderlocal class?
+    // FIXME: SHould this rather happen in the addressproviderlocal class?
     for (const auto &dirEntry : QDirListing(baseDir, QDirListing::IteratorFlag::Recursive)) {
         if (dirEntry.fileName().endsWith(u".vcf")) {
             const QString file = dirEntry.fileInfo().canonicalFilePath();

--- a/src/models/datemodel.cpp
+++ b/src/models/datemodel.cpp
@@ -413,7 +413,7 @@ DocDigest DateModel::digest(const QModelIndex& indx) const
 
 void DateModel::removeAllData()
 {
-    // the destructor of the TreeItem removes the entire tree recursivly
+    // the destructor of the TreeItem removes the entire tree recursively
     delete rootItem;
     rootItem = new TreeItem(0);
 }

--- a/src/models/docbasemodel.cpp
+++ b/src/models/docbasemodel.cpp
@@ -162,7 +162,7 @@ void DocBaseModel::resetData()
 void DocBaseModel::slotAddresseeFound( const QString& uid, const KContacts::Addressee& contact)
 {
     // FIXME: Update the data in the model and update the view accordingly.
-    // Given that the view is updated so often, it does not seem to be neccessary
+    // Given that the view is updated so often, it does not seem to be necessary
     // to do at all. Maybe later...
     Q_UNUSED(uid);
     Q_UNUSED(contact);

--- a/src/models/globalcontactmodel.h
+++ b/src/models/globalcontactmodel.h
@@ -33,7 +33,7 @@ namespace Akonadi
  * @short Provides the global model for all contacts
  *
  * This model provides the EntityTreeModel for all contacts.
- * The model is accessable via the static instance() method.
+ * The model is accessible via the static instance() method.
  */
 class GlobalContactModel
 {

--- a/src/myidentity.h
+++ b/src/myidentity.h
@@ -33,7 +33,7 @@ class AddressProvider;
  * 1. There is just a UUID in the settings file stored under userUid(),
  *    which contains the id under which the own identify can be found in
  *    the addressbook through the backend.
- * 2. If the id is non existant or empty, the identity is read from a file
+ * 2. If the id is non existent or empty, the identity is read from a file
  *    stored in a specific path. It is written by the prefsdialog.
  */
 
@@ -58,7 +58,7 @@ public:
 
     QString identityFile();
 
-    // returns the addressee that was found on the last attemt to look up the own identity.
+    // returns the addressee that was found on the last attempt to look up the own identity.
     // If there was no call to load before, the returned addressee is obviously empty.
     KContacts::Addressee contact() const;
 

--- a/src/numbercycle.cpp
+++ b/src/numbercycle.cpp
@@ -263,7 +263,7 @@ int NumberCycles::increaseLocalCounter(const QString& ncName)
             return newCnt;
         }
         attempt++;
-        QThread::msleep(2*attempt); // Sleep a short time before trying agian. Lock should be gone after that.
+        QThread::msleep(2*attempt); // Sleep a short time before trying again. Lock should be gone after that.
     }
     if (attempt == MaxAttempt) {
         qDebug() << "Could not lock the numbercycle file";

--- a/src/portal.cpp
+++ b/src/portal.cpp
@@ -76,7 +76,7 @@
 #include "xmldocindex.h"
 #include "myidentity.h"
 
-// Litte class diagram to describe the main view of Kraft:
+// Little class diagram to describe the main view of Kraft:
 //
 //            +-----------------+
 //            | Portal          |       Provides the main window
@@ -460,7 +460,7 @@ void Portal::slotStartupChecks()
 
     }
 
-    // Database is up and runing!
+    // Database is up and running!
     // Check the document storage and see if the docs are converted already.
     QString basePath = DefaultProvider::self()->kraftV2Dir();
     if (basePath.isEmpty()) {
@@ -562,7 +562,7 @@ void Portal::slotFollowUpDocument()
 
     QStringList followers = dt.follower();
     if ( followers.count() > 0 ) {
-        // only if there are currently followers defined, if not the default wiht
+        // only if there are currently followers defined, if not the default with
         // all doc types works.
         wiz.setAvailDocTypes( dt.follower() );
     }
@@ -860,7 +860,7 @@ void Portal::openInMailer(const QString& addrUuid, const KContacts::Addressee& c
                this, &Portal::openInMailer);
 
     if( !contact.isEmpty() ) {
-        mailReceiver = contact.fullEmail(); // the prefered email
+        mailReceiver = contact.fullEmail(); // the preferred email
     }
 
     QStringList args;
@@ -1177,7 +1177,7 @@ void Portal::createROView( DocGuardedPtr doc )
 // Note: The modified flag has to come extra here from the the signal emitter
 // even though the Doc object contains a modified flag. However, that is always
 // false, because the doc was saved before in the emitting function.
-// Still, it needs to be known here if the document was modfied before.
+// Still, it needs to be known here if the document was modified before.
 void Portal::slotViewClosed( bool success, DocGuardedPtr doc, bool modified )
 {
     // doc is only valid on success!

--- a/src/portal.h
+++ b/src/portal.h
@@ -44,7 +44,7 @@ class Portal : public QMainWindow
   friend class KraftView;
 
   public:
-    /** construtor of Portal, calls all init functions to create the application.
+    /** constructor of Portal, calls all init functions to create the application.
      */
     Portal( QWidget* parent = 0, QCommandLineParser *commandLineParser = 0, const char* name = 0);
 
@@ -61,7 +61,7 @@ class Portal : public QMainWindow
      */
     void initView();
     /** queryClose is called by KTMainWindow on each closeEvent of a window. Against the
-     * default implementation (only returns true), this calles saveModified() on the document object to ask if the document shall
+     * default implementation (only returns true), this calls saveModified() on the document object to ask if the document shall
      * be saved if Modified; on cancel the closeEvent is rejected.
      * @see KTMainWindow#queryClose
      * @see KTMainWindow#closeEvent

--- a/src/portalview.cpp
+++ b/src/portalview.cpp
@@ -380,7 +380,7 @@ QString PortalView::systemView( const QString& htmlMsg ) const
     }
     obj.setProperty( "WEASYPRINT_TOOL", wp);
 
-    // aknowledgement
+    // acknowledgement
     obj.setProperty( "ICON_ACKNOWLEDGEMENT_LABEL", i18n("Some Icons are made by") );
     obj.setProperty( "ACKNOWLEGEMENT_LABEL", i18n( "Acknowledgements" ) );
 

--- a/src/tagman.cpp
+++ b/src/tagman.cpp
@@ -165,7 +165,7 @@ void TagTemplateMan::load()
 
   /* read tag templates from db */
   /* FIXME: The sortKey sort is not working because the sortKey is not correctly set on write */
-  /* With the initial db setup come useful sortKeys, thats why we still sort for it. */
+  /* With the initial db setup come useful sortKeys, that's why we still sort for it. */
   QSqlQuery q1( "SELECT tagTmplID, name, description, color FROM tagTemplates ORDER BY sortKey, name" );
   while( q1.next()) {
     dbID id( q1.value(0).toInt() );

--- a/src/templkatalogview.h
+++ b/src/templkatalogview.h
@@ -42,7 +42,7 @@ class TemplKatalogView: public KatalogView
   Q_OBJECT
 
 public:
-  /** construtor of KraftApp, calls all init functions to create the application.
+  /** constructor of KraftApp, calls all init functions to create the application.
    */
   TemplKatalogView(QWidget* parent=0, const char* name=0);
   TemplKatalogView(const QString& katToShow, QWidget* parent=0, const char* name=0);

--- a/src/unitmanager.cpp
+++ b/src/unitmanager.cpp
@@ -172,7 +172,7 @@ int UnitManager::getUnitIDSingular( const QString& einheitStr )
 
     if( tmp.einheitSingular() == einheitStr ||
         tmp.einheitPlural()   == einheitStr ) {
-      // qDebug() << "Thats it, returning " << tmp.id();
+      // qDebug() << "That's it, returning " << tmp.id();
       return tmp.id();
     }
   }
@@ -186,7 +186,7 @@ QString UnitManager::getECE20(const QString& einheitStr)
     for( Einheit tmp: mUnits ) {
       if( tmp.einheitSingular() == einheitStr ||
           tmp.einheitPlural()   == einheitStr ) {
-        // qDebug() << "Thats it, returning " << tmp.id();
+        // qDebug() << "That's it, returning " << tmp.id();
         return tmp.ec20();
       }
     }

--- a/src/unitmanager.h
+++ b/src/unitmanager.h
@@ -43,7 +43,7 @@ class UnitManager
     int getUnitIDSingular( const QString& einheit );
     QString getECE20(const QString& einheitStr);
 
-    // Workaround: since the unit table does not have an auto update id coloum,
+    // Workaround: since the unit table does not have an auto update id column,
     // this function calculates the next free unit id to save a new one.
     int nextFreeId();
 

--- a/tests/t_xmlsaver.cpp
+++ b/tests/t_xmlsaver.cpp
@@ -60,7 +60,7 @@ private Q_SLOTS:
         QVERIFY(!kraftHome.isEmpty());
         const QString src{kraftHome+"/../xml/kraftdoc.xml"};
         QVERIFY(QFile::copy(src, filePath));
-        qDebug() << "Copyied from" << src << "to filepath" << filePath;
+        qDebug() << "Copied from" << src << "to filepath" << filePath;
 
         // generate the index
         XmlDocIndex indx;

--- a/tools/findcontact.cpp
+++ b/tools/findcontact.cpp
@@ -141,11 +141,11 @@ public:
         AddressProvider::LookupState state = _addressProvider->lookupAddressee(uid);
         if( state == AddressProvider::LookupFromCache ) {
             const KContacts::Addressee addressee = _addressProvider->getAddresseeFromCache(uid);
-            // this cant actually happen because the cache cannot be prefilled.
+            // this can't actually happen because the cache cannot be prefilled.
             slotAddresseeFound( QString(), addressee );
         } else if( state == AddressProvider::LookupOngoing ) {
         } else if( state == AddressProvider::LookupStarted ) {
-            // thats the supposed return type.
+            // that's the supposed return type.
         } else if( state == AddressProvider::LookupNotFound ||
                    state == AddressProvider::BackendError   ||
                    state == AddressProvider::ItemError ) {


### PR DESCRIPTION
- "accellerated" -> "accelerated"
- "acces" -> "access"
- "accessable" -> "accessible"
- "adress" -> "address"
- "agian" -> "again"
- "aknowledgement" -> "acknowledgement"
- "ambigous" -> "ambiguous"
- "appropiate" -> "appropriate"
- "attemt" -> "attempt"
- "attribte" -> "attribute"
- "attributs" / "attriutes" -> "attributes"
- "beautifull" -> "beautiful"
- "calles" -> "calls"
- "calulation" -> "calculation"
- "cant" -> "can't"
- "coloum" / "colum" -> "column"
- "Colum" -> "Column"
- "configureable" -> "configurable"
- "consitent" -> "consistent"
- "construtor" -> "constructor"
- "Copyied" -> "Copied"
- "docuemnt" -> "document"
- "everyting" -> "everything"
- "existant" -> "existent"
- "explicitely" -> "explicitly"
- "Funktionality" -> "Functionality"
- "genral" -> "general"
- "happpen" -> "happen"
- "healty" -> "healthy"
- "higer" -> "higher"
- "hirarchical" -> "hierarchical"
- "independant" -> "independent"
- "initialzing" -> "initializing"
- "instanciating" -> "instantiating"
- "Litte" -> "Little"
- "measureable" -> "measurable"
- "meterial" -> "material"
- "modfied" -> "modified"
- "nead" -> "need"
- "neccessary" -> "necessary"
- "ot" -> "to"
- "persistance" -> "persistence"
- "prefered" -> "preferred"
- "receipient" -> "recipient"
- "recursivly" -> "recursively"
- "reproducable" -> "reproducible"
- "retore" -> "restore"
- "reuslt" -> "result"
- "runing" -> "running"
- "settigs" -> "settings"
- "Shft" -> "Shift"
- "simle" -> "simple"
- "softare" -> "software"
- "Substancial" -> "Substantial"
- "substract" -> "subtract"
- "Substract" -> "Subtract"
- "substracted" -> "subtracted"
- "thats" -> "that's"
- "Thats" -> "That's"
- "therefor" -> "therefore"
- "Tranformation" -> "Transformation"
- "transfered" -> "transferred"
- "wich" -> "which"
- "wiht" -> "with"
- "wont" -> "won't"

Found using codespell.